### PR TITLE
Lyn Corbray

### DIFF
--- a/pack/VDS.json
+++ b/pack/VDS.json
@@ -274,7 +274,7 @@
         "is_loyal": false,
         "is_military": true,
         "is_power": false,
-        "is_unique": false,
+        "is_unique": true,
         "name": "Lyn Corbray",
         "pack_code": "VDS",
         "position": 17,


### PR DESCRIPTION
Weird thing: here (http://thronesdb.com/set/VDS) if you hover over the faction-specific cards, they all say Loyal, but on the individual card pages and in the .json data it's Non-Loyal.

Also, Common Cause shows "Claim: undefined" when hovering.

BTW, some glitch: in the My Decks section (http://thronesdb.com/decks) the Agenda cards don't show up.