### PR TITLE
split designer attribution to its own field

### DIFF
--- a/pack/GtR.json
+++ b/pack/GtR.json
@@ -369,6 +369,7 @@
         "claim": 1,
         "code": "06040",
         "deck_limit": 2,
+        "designer": "Card design by 2014 Overall World Champion, Alexander Hynes.",
         "faction_code": "neutral",
         "illustrator": "Serena Malyon",
         "income": 4,
@@ -381,7 +382,7 @@
         "position": 40,
         "quantity": 3,
         "reserve": 7,
-        "text": "Each player may play events in his or her discard pile as if they were in his or her hand.\n<b>Forced Reaction:</b> After an event is placed in a discard pile, remove it from the game.\n<b>Card design by 2014 Overall World Champion, Alexander Hynes.</b>",
+        "text": "Each player may play events in his or her discard pile as if they were in his or her hand.\n<b>Forced Reaction:</b> After an event is placed in a discard pile, remove it from the game.",
         "traits": "Legacy.",
         "type_code": "plot"
     }

--- a/pack/HoT.json
+++ b/pack/HoT.json
@@ -110,6 +110,7 @@
         "code": "09006",
         "cost": 4,
         "deck_limit": 3,
+        "designer": "Card design by 2011 European Melee Champion, Gregoire Lefebvre.",
         "faction_code": "tyrell",
         "illustrator": "Magali Villeneuve",
         "is_intrigue": true,
@@ -123,7 +124,7 @@
         "position": 6,
         "quantity": 3,
         "strength": 3,
-        "text": "While Margaery Tyrell is attacking, she gets +1 STR for each defending character.\n<b>Reaction:</b> After Margaery Tyrell is declared as an attacker, choose and kneel a character controlled by the defending player. That character is participating in the challenge as a defender.\n<b>Card design by 2011 European Melee Champion, Gregoire Lefebvre.</b>",
+        "text": "While Margaery Tyrell is attacking, she gets +1 STR for each defending character.\n<b>Reaction:</b> After Margaery Tyrell is declared as an attacker, choose and kneel a character controlled by the defending player. That character is participating in the challenge as a defender.",
         "traits": "Lady. Queen.",
         "type_code": "character"
     },
@@ -779,6 +780,7 @@
         "code": "09040",
         "cost": 4,
         "deck_limit": 3,
+        "designer": "Card design by 2013 Overall World Champion, Ryan Jones.",
         "faction_code": "neutral",
         "illustrator": "Colin Boyer",
         "is_intrigue": false,
@@ -792,7 +794,7 @@
         "position": 40,
         "quantity": 3,
         "strength": 3,
-        "text": "Ambush (4).\n<b>Challenges Action:</b> Choose a character in a dead pile. Until the end of the phase, Faceless Man gains each of that character's printed challenge icons, keywords, faction affiliations, and <i>Traits</i>. (Limit once per phase.)\n<b>Card design by 2013 Overall World Champion, Ryan Jones.</b>",
+        "text": "Ambush (4).\n<b>Challenges Action:</b> Choose a character in a dead pile. Until the end of the phase, Faceless Man gains each of that character's printed challenge icons, keywords, faction affiliations, and <i>Traits</i>. (Limit once per phase.)",
         "traits": "",
         "type_code": "character"
     },

--- a/pack/JtO.json
+++ b/pack/JtO.json
@@ -83,6 +83,7 @@
     {
         "code": "08039",
         "deck_limit": 1,
+        "designer": "Card design by 2011 Overall World Champion, Corey Faherty.",
         "faction_code": "neutral",
         "illustrator": "Kristina Carroll",
         "is_loyal": false,
@@ -92,7 +93,7 @@
         "pack_code": "JtO",
         "position": 39,
         "quantity": 3,
-        "text": "After all agendas are announced, search your deck for a non-limited unique location with printed cost 3 or lower and put it into play. That location cannot be discarded from play by card effects.\nYou cannot spend more than 4 gold during setup.\n<b>Card design by 2011 Overall World Champion, Corey Faherty.</b>",
+        "text": "After all agendas are announced, search your deck for a non-limited unique location with printed cost 3 or lower and put it into play. That location cannot be discarded from play by card effects.\nYou cannot spend more than 4 gold during setup.",
         "traits": "Dream.",
         "type_code": "agenda"
     }

--- a/pack/Km.json
+++ b/pack/Km.json
@@ -57,6 +57,7 @@
         "claim": 1,
         "code": "08060",
         "deck_limit": 1,
+        "designer": "Card design by 2013 North American Champion, Steven Simoni.",
         "faction_code": "neutral",
         "illustrator": "Jacob Murray",
         "income": 5,
@@ -68,7 +69,7 @@
         "position": 60,
         "quantity": 3,
         "reserve": 6,
-        "text": "Skip the standing phase this round.\n<b>Card design by 2013 North American Champion, Steven Simoni.</b>",
+        "text": "Skip the standing phase this round.",
         "traits": "Winter.",
         "type_code": "plot"
     }

--- a/pack/LoCR.json
+++ b/pack/LoCR.json
@@ -46,6 +46,7 @@
         "code": "05003",
         "cost": 6,
         "deck_limit": 3,
+        "designer": "Card design by 2012 Chinese National Champion, Bing Ouyang.",
         "faction_code": "lannister",
         "illustrator": "Sebastian Giacobino",
         "is_intrigue": true,
@@ -59,7 +60,7 @@
         "position": 3,
         "quantity": 3,
         "strength": 4,
-        "text": "<b>Reaction:</b> After you marshal Ser Kevan Lannister, choose a [lannister] or neutral location or attachment in your discard pile and put it into play.\n<b>Card design by 2012 Chinese National Champion, Bing Ouyang.</b>",
+        "text": "<b>Reaction:</b> After you marshal Ser Kevan Lannister, choose a [lannister] or neutral location or attachment in your discard pile and put it into play.",
         "traits": "Knight. Lord. Small Council.",
         "type_code": "character"
     },
@@ -877,6 +878,7 @@
     {
         "code": "05045",
         "deck_limit": 1,
+        "designer": "Card Design by 2013 Joust World Champion, Álvaro Rodriguez.",
         "faction_code": "neutral",
         "illustrator": "Serena Malyon",
         "is_loyal": false,
@@ -886,7 +888,7 @@
         "pack_code": "LoCR",
         "position": 45,
         "quantity": 3,
-        "text": "Your plot deck must be 12 cards, including exactly 5 different <i>Scheme</i> cards. During the plot phase, <i>Scheme</i> cards are not considered to be in your plot deck.\n<b>Reaction:</b> After you win an [intrigue] challenge by 5 or more STR, kneel your faction card to reveal a <i>Scheme</i> plot. If that card leaves play, remove it from the game.\n<b>Card Design by 2013 Joust World Champion, Álvaro Rodriguez.</b>",
+        "text": "Your plot deck must be 12 cards, including exactly 5 different <i>Scheme</i> cards. During the plot phase, <i>Scheme</i> cards are not considered to be in your plot deck.\n<b>Reaction:</b> After you win an [intrigue] challenge by 5 or more STR, kneel your faction card to reveal a <i>Scheme</i> plot. If that card leaves play, remove it from the game.",
         "traits": "Song.",
         "type_code": "agenda"
     },

--- a/pack/NMG.json
+++ b/pack/NMG.json
@@ -360,6 +360,7 @@
         "claim": 1,
         "code": "02079",
         "deck_limit": 1,
+        "designer": "Card design by 2005 World Champion, John M. Bruno.",
         "faction_code": "neutral",
         "illustrator": "Thomas Denmark",
         "income": 3,
@@ -372,7 +373,7 @@
         "position": 79,
         "quantity": 3,
         "reserve": 6,
-        "text": "<b>Forced Reaction:</b> After the challenges phase begins, return each character with printed cost 3 or lower to its owner's hand.\n<b>Card design by 2005 World Champion, John M. Bruno.</b>",
+        "text": "<b>Forced Reaction:</b> After the challenges phase begins, return each character with printed cost 3 or lower to its owner's hand.",
         "traits": "Omen. Winter.",
         "type_code": "plot"
     },

--- a/pack/OR.json
+++ b/pack/OR.json
@@ -333,6 +333,7 @@
         "code": "06098",
         "cost": 1,
         "deck_limit": 3,
+        "designer": "Card design by 2004 World Champion, Greg Atkinson.",
         "faction_code": "neutral",
         "illustrator": "Regis Moulun",
         "is_loyal": false,
@@ -342,7 +343,7 @@
         "pack_code": "OR",
         "position": 98,
         "quantity": 3,
-        "text": "<b>Challenges Action:</b> Pay 1 gold and kneel Flea Bottom to put a character with printed cost 3 or lower into play from your discard pile. At the end of the phase, if that card is still in play, place it on the bottom of your deck.\n<b>Card design by 2004 World Champion, Greg Atkinson.</b>",
+        "text": "<b>Challenges Action:</b> Pay 1 gold and kneel Flea Bottom to put a character with printed cost 3 or lower into play from your discard pile. At the end of the phase, if that card is still in play, place it on the bottom of your deck.",
         "traits": "King's Landing.",
         "type_code": "location"
     },
@@ -350,6 +351,7 @@
         "code": "06099",
         "cost": 0,
         "deck_limit": 3,
+        "designer": "Card design by 2013 Melee World Champion, Ryan Jones.",
         "faction_code": "neutral",
         "illustrator": "Christine Thomas",
         "is_loyal": false,
@@ -359,7 +361,7 @@
         "pack_code": "OR",
         "position": 99,
         "quantity": 3,
-        "text": "<b>Action:</b> If it is not the taxation phase, kneel your faction card and return a character to your hand to gain gold equal to that character's printed cost. Until the end of the round, you cannot marshal or put into play any card with the same title as that character.\n<b>Card design by 2013 Melee World Champion, Ryan Jones.</b>",
+        "text": "<b>Action:</b> If it is not the taxation phase, kneel your faction card and return a character to your hand to gain gold equal to that character's printed cost. Until the end of the round, you cannot marshal or put into play any card with the same title as that character.",
         "traits": "",
         "type_code": "event"
     },

--- a/pack/TBWB.json
+++ b/pack/TBWB.json
@@ -311,6 +311,7 @@
         "code": "06117",
         "cost": 7,
         "deck_limit": 3,
+        "designer": "Card design by 2014 European Melee Champion, Jakob Hultman.",
         "faction_code": "neutral",
         "illustrator": "Joel Hustak",
         "is_intrigue": false,
@@ -324,7 +325,7 @@
         "position": 117,
         "quantity": 3,
         "strength": null,
-        "text": "Renown.\nX is the number of kiss tokens Beric Dondarrion has.\n<b>Forced Reaction:</b> After you marshal Beric Dondarrion, place 6 kiss tokens on him. (Cannot be canceled.)\n<b>Interrupt:</b> When Beric Dondarrion would be killed, discard a kiss token from him to save him.\n<b>Card design by 2014 European Melee Champion, Jakob Hultman.</b>",
+        "text": "Renown.\nX is the number of kiss tokens Beric Dondarrion has.\n<b>Forced Reaction:</b> After you marshal Beric Dondarrion, place 6 kiss tokens on him. (Cannot be canceled.)\n<b>Interrupt:</b> When Beric Dondarrion would be killed, discard a kiss token from him to save him.",
         "traits": "Knight. Lord. R'hllor.",
         "type_code": "character"
     },

--- a/pack/TC.json
+++ b/pack/TC.json
@@ -82,6 +82,7 @@
         "code": "04105",
         "cost": 6,
         "deck_limit": 3,
+        "designer": "Card design by 2009 Melee World Champion, Jonathan Benton.",
         "faction_code": "thenightswatch",
         "illustrator": "Jason Jenicke",
         "is_intrigue": false,
@@ -95,7 +96,7 @@
         "position": 105,
         "quantity": 3,
         "strength": 5,
-        "text": "Renown. No attachments except <i>Weapon</i>.\n<b>Reaction:</b> After you win a [military] challenge in which Qhorin Halfhand is participating, choose and kill a non-unique character with lower STR than his controlled by the losing opponent.\n<b>Card design by 2009 Melee World Champion, Jonathan Benton.</b>",
+        "text": "Renown. No attachments except <i>Weapon</i>.\n<b>Reaction:</b> After you win a [military] challenge in which Qhorin Halfhand is participating, choose and kill a non-unique character with lower STR than his controlled by the losing opponent.",
         "traits": "Ranger.",
         "type_code": "character"
     },

--- a/pack/TFoA.json
+++ b/pack/TFoA.json
@@ -367,6 +367,7 @@
         "claim": 1,
         "code": "06060",
         "deck_limit": 1,
+        "designer": "Card design by 2014 North American Champion, Jonathan Andrews.",
         "faction_code": "neutral",
         "illustrator": "Ryan Valle",
         "income": 4,
@@ -379,7 +380,7 @@
         "position": 60,
         "quantity": 3,
         "reserve": 6,
-        "text": "<b>When Revealed:</b> Choose an opponent. That player chooses 2 non-<i>Army</i> characters, each with printed cost 6 or higher. Then, that player chooses and kneels 1 of those characters. Kill the other (cannot be saved).\n<b>Card design by 2014 North American Champion, Jonathan Andrews.</b>",
+        "text": "<b>When Revealed:</b> Choose an opponent. That player chooses 2 non-<i>Army</i> characters, each with printed cost 6 or higher. Then, that player chooses and kneels 1 of those characters. Kill the other (cannot be saved).",
         "traits": "War.",
         "type_code": "plot"
     }

--- a/pack/TKP.json
+++ b/pack/TKP.json
@@ -200,6 +200,7 @@
         "code": "02051",
         "cost": 4,
         "deck_limit": 3,
+        "designer": "Card design by 2003 World Champion, Casey Galvan.",
         "faction_code": "greyjoy",
         "illustrator": "Leo Winstead",
         "is_intrigue": false,
@@ -213,7 +214,7 @@
         "position": 51,
         "quantity": 3,
         "strength": 4,
-        "text": "<b>Reaction:</b> After you marshal Newly-Made Lord, choose a non-limited location with printed cost 3 or lower, and discard it from play.\n<b>Card design by 2003 World Champion, Casey Galvan.</b>",
+        "text": "<b>Reaction:</b> After you marshal Newly-Made Lord, choose a non-limited location with printed cost 3 or lower, and discard it from play.",
         "traits": "Lord.",
         "type_code": "character"
     },

--- a/pack/TRW.json
+++ b/pack/TRW.json
@@ -25,6 +25,7 @@
         "code": "06062",
         "cost": 2,
         "deck_limit": 3,
+        "designer": "Card Design by 2015 Melee North American Champion, Brian Aurelio.",
         "faction_code": "stark",
         "illustrator": "Sara Biddle",
         "is_loyal": false,
@@ -34,7 +35,7 @@
         "pack_code": "TRW",
         "position": 62,
         "quantity": 3,
-        "text": "<b>Action:</b> During a [military] challenge, kneel Winterfell Archery Range to choose a participating character with STR 3 or lower, and remove it from the challenge.\n<b>Card Design by 2015 Melee North American Champion, Brian Aurelio.</b>",
+        "text": "<b>Action:</b> During a [military] challenge, kneel Winterfell Archery Range to choose a participating character with STR 3 or lower, and remove it from the challenge.",
         "traits": "Winterfell.",
         "type_code": "location"
     },

--- a/pack/TRtW.json
+++ b/pack/TRtW.json
@@ -197,6 +197,7 @@
         "code": "02031",
         "cost": 5,
         "deck_limit": 3,
+        "designer": "Card design by 2011 European Joust Champion, Martí Foz Hernandez.",
         "faction_code": "greyjoy",
         "illustrator": "Nacho Molina",
         "is_intrigue": true,
@@ -210,7 +211,7 @@
         "position": 31,
         "quantity": 3,
         "strength": 4,
-        "text": "<b>Reaction:</b> After you win an unopposed challenge in which a unique [greyjoy] character is participating, either: draw 1 card, or discard the top 3 cards from each opponent's deck. (Limit once per phase.)\n<b>Card design by 2011 European Joust Champion, Martí Foz Hernandez.</b>",
+        "text": "<b>Reaction:</b> After you win an unopposed challenge in which a unique [greyjoy] character is participating, either: draw 1 card, or discard the top 3 cards from each opponent's deck. (Limit once per phase.)",
         "traits": "House Harlaw. Lord.",
         "type_code": "character"
     },

--- a/pack/WotN.json
+++ b/pack/WotN.json
@@ -68,6 +68,7 @@
         "code": "03004",
         "cost": 6,
         "deck_limit": 3,
+        "designer": "Card design by 2009 World Champion, Erick A. Butzlaff.",
         "faction_code": "stark",
         "illustrator": "Cris Griffin",
         "is_intrigue": false,
@@ -81,7 +82,7 @@
         "position": 4,
         "quantity": 3,
         "strength": 4,
-        "text": "Renown.\nWhile The Blackfish has 4 or more power, each <i>House Tully </i>character you control does not kneel when declared as an attacker.\n<b>Reaction:</b> After you win a [military] challenge as the attacking player, draw 1 card. (Limit once per phase.)\n<b>Card design by 2009 World Champion, Erick A. Butzlaff.</b>",
+        "text": "Renown.\nWhile The Blackfish has 4 or more power, each <i>House Tully </i>character you control does not kneel when declared as an attacker.\n<b>Reaction:</b> After you win a [military] challenge as the attacking player, draw 1 card. (Limit once per phase.)",
         "traits": "House Tully. Knight. Lord.",
         "type_code": "character"
     },
@@ -892,6 +893,7 @@
         "claim": 1,
         "code": "03046",
         "deck_limit": 2,
+        "designer": "Card design by 2012 North American Champion, Dan Seefeldt.",
         "faction_code": "stark",
         "illustrator": "Jake Murray",
         "income": 3,
@@ -904,7 +906,7 @@
         "position": 46,
         "quantity": 3,
         "reserve": 6,
-        "text": "<b>When Revealed:</b> Search your deck for a <i>Direwolf</i> card, reveal it, and add it to your hand. If that card's printed cost is 3 or lower, you may put it into play instead. Shuffle your deck.\n<b>Card design by 2012 North American Champion, Dan Seefeldt.</b>",
+        "text": "<b>When Revealed:</b> Search your deck for a <i>Direwolf</i> card, reveal it, and add it to your hand. If that card's printed cost is 3 or lower, you may put it into play instead. Shuffle your deck.",
         "traits": "Winter.",
         "type_code": "plot"
     },

--- a/schema/card_schema.json
+++ b/schema/card_schema.json
@@ -31,6 +31,17 @@
             "minimum": 0,
             "type": "integer"
         },
+        "designer": {
+            "oneOf": [
+                {
+                    "minLength": 0,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "faction_code": {
             "enum": [
                 "baratheon",


### PR DESCRIPTION
as discussed in #206, attribution to the card's designer has been given its own property field to differentiate its text from the card's functional rules text.

TODO: Implement the "designer" card property in the thronesdb UI code