### PR TITLE
Add missing income modifiers to Gate locations

### DIFF
--- a/pack/AtG.json
+++ b/pack/AtG.json
@@ -37,7 +37,7 @@
         "pack_code": "AtG",
         "position": 2,
         "quantity": 3,
-        "text": "Limited.\n<b>Challenges Action:</b> If each character you control has the [stark] affiliation, sacrifice Old Gate to draw 2 cards.",
+        "text": "Limited.\n<b>Challenges Action:</b> If each character you control has the [stark] affiliation, sacrifice Old Gate to draw 2 cards.\n+1 Income.",
         "traits": "King's Landing.",
         "type_code": "location"
     },
@@ -79,7 +79,7 @@
         "pack_code": "AtG",
         "position": 4,
         "quantity": 3,
-        "text": "Limited.\n<b>Challenges Action:</b> If you control a character with the highest STR in play, sacrifice Gate of the Gods to draw 2 cards.",
+        "text": "Limited.\n<b>Challenges Action:</b> If you control a character with the highest STR in play, sacrifice Gate of the Gods to draw 2 cards.\n+1 Income.",
         "traits": "King's Landing. The Seven.",
         "type_code": "location"
     },
@@ -98,7 +98,7 @@
         "pack_code": "AtG",
         "position": 8,
         "quantity": 3,
-        "text": "Limited.\n<b>Challenges Action:</b> If you have 5 or more power on your faction card, sacrifice King's Gate to draw 2 cards.",
+        "text": "Limited.\n<b>Challenges Action:</b> If you have 5 or more power on your faction card, sacrifice King's Gate to draw 2 cards.\n+1 Income.",
         "traits": "King's Landing.",
         "type_code": "location"
     },


### PR DESCRIPTION
Apologies for the churn, but I missed the income modifiers on the new At the Gates locations.